### PR TITLE
add exclude for router upgrade

### DIFF
--- a/angular-metadata.tsconfig.json
+++ b/angular-metadata.tsconfig.json
@@ -16,6 +16,7 @@
   "exclude": [
     "**/__path__",
     "**/schematics",
+    "node_modules/@angular/router/upgrade*",
     "node_modules/@angular/bazel/**",
     "node_modules/@angular/compiler-cli/**",
     "node_modules/@angular/**/testing/**"


### PR DESCRIPTION
When I tried to use this in one app with @angular/router, have this error => 
<pre>
node_modules/@angular/router/upgrade/src/upgrade.d.ts(9,31): error TS2307: Cannot find module '@angular/upgrade/static'.
</pre>
With this fix you don't need install anything more.